### PR TITLE
fix(builder): normalize initial form defaults to avoid invalid submit values

### DIFF
--- a/apps/web/app/(builder)/lib/core/sync.ts
+++ b/apps/web/app/(builder)/lib/core/sync.ts
@@ -140,9 +140,9 @@ function syncFieldValues(
 
             // Array: always preserve rows
             if (field.type === "array") {
-                if (currentVal !== undefined) {
+                if (Array.isArray(currentVal)) {
                     result[name] = currentVal;
-                } else if (defaultVal !== undefined) {
+                } else if (Array.isArray(defaultVal)) {
                     result[name] = defaultVal;
                 } else {
                     result[name] = [];

--- a/apps/web/app/(builder)/lib/properties.ts
+++ b/apps/web/app/(builder)/lib/properties.ts
@@ -23,6 +23,16 @@ export function extractDefaults(fields: Field[]): Record<string, unknown> {
   const defaults: Record<string, unknown> = {};
   for (const field of fields) {
     if ("name" in field && field.name) {
+      // Array values must always be arrays at runtime.
+      if (field.type === "array") {
+        const explicitDefault = (field as unknown as Record<string, unknown>)
+          .defaultValue;
+        defaults[field.name] = Array.isArray(explicitDefault)
+          ? deepClone(explicitDefault)
+          : [];
+        continue;
+      }
+
       if ("defaultValue" in field) {
         // Deep clone to avoid frozen object references from Zustand/immer
         defaults[field.name] = deepClone(

--- a/apps/web/app/(builder)/lib/registry.ts
+++ b/apps/web/app/(builder)/lib/registry.ts
@@ -141,7 +141,7 @@ export const builderFieldRegistry: BuilderFieldRegistry = {
       icon: CheckmarkSquare02Icon,
       category: "selection",
     },
-    defaultProps: { type: "checkbox", label: "Checkbox" },
+    defaultProps: { type: "checkbox", label: "Checkbox", defaultValue: false },
     properties: checkboxFieldProperties,
   },
   "checkbox-group": {


### PR DESCRIPTION
**Key Changes:**

- keep selection field defaults aligned with schema expectations
- force array defaults to [] during default extraction and runtime sync
- prevent untouched fields from failing validation (refs #50)


Closes #50 