### PR TITLE
fix(ci): run Validate on changeset-release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - changeset-release/**
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Description

The `Validate` required status check was permanently stuck at "Waiting for status to be reported" on every version PR created by the `changesets/action` bot. This meant the PR could never be merged without bypassing branch protection rules.

## Key Changes

### Other

- Added `changeset-release/**` to the `push` trigger in `ci.yml` so the `Validate` job runs when the release bot pushes to its branch, satisfying the required status check on the version PR.

## Type of change

- [x] `fix` (Bug fix)

## Related Issues

- Closes #