### PR TITLE
feat(form-react): add useWatch hook and polymorphic as prop to Form

### DIFF
--- a/.changeset/form-react-use-watch.md
+++ b/.changeset/form-react-use-watch.md
@@ -1,0 +1,8 @@
+---
+"@buildnbuzz/form-react": patch
+---
+
+Add useWatch hook and polymorphic `as` prop to Form component.
+
+- Implement `useWatch` hook for accessing form state.
+- Add polymorphic `as` prop to `Form` component for custom rendering.

--- a/packages/form-react/src/contexts/hooks/use-field-options.integration.test.tsx
+++ b/packages/form-react/src/contexts/hooks/use-field-options.integration.test.tsx
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { useFieldOptions } from "./use-field-options";
 import { FieldContext } from "../field-context";
-import type { FormRegistries, OptionResolverRegistry } from "@buildnbuzz/form-core";
+import type { OptionResolverRegistry } from "@buildnbuzz/form-core";
 import type { FieldFormApi, UnknownData } from "../../types";
 
 describe("useFieldOptions - cascading dropdown integration", () => {

--- a/packages/form-react/src/field.tsx
+++ b/packages/form-react/src/field.tsx
@@ -109,9 +109,10 @@ export function Field<TFormData extends UnknownData = UnknownData>({
     return mergeRegistries(globalRegistries, normalized) ?? {};
   }, [globalRegistries, registries, customValidators, optionResolvers]);
   const pointer = useMemo(() => {
-    if (field.name.startsWith("/")) return field.name;
-    if (field.name.includes(".")) return fromDotNotation(field.name);
-    return `/${escapePointer(field.name)}`;
+    const name = field.name ?? "";
+    if (name.startsWith("/")) return name;
+    if (name.includes(".")) return fromDotNotation(name);
+    return `/${escapePointer(name)}`;
   }, [field.name]);
   const basePointer = useMemo(() => getParentPointer(pointer), [pointer]);
   const resolvedField = useMemo(
@@ -236,19 +237,19 @@ export function Field<TFormData extends UnknownData = UnknownData>({
       resolveBooleanExpr(resolvedField.required, ctx, mergedRegistries.fns);
 
     if (!isConditionMet) {
-      return <ConditionalFieldRemover form={form} name={field.name} />;
+      return <ConditionalFieldRemover form={form} name={field.name ?? ""} />;
     }
 
     if (isHidden) {
       return (
-        <form.Field name={field.name as never} validators={mergedValidators}>
+        <form.Field name={(field.name ?? "") as never} validators={mergedValidators}>
           {() => null}
         </form.Field>
       );
     }
 
     return (
-      <form.Field name={field.name as never} validators={mergedValidators}>
+      <form.Field name={(field.name ?? "") as never} validators={mergedValidators}>
         {(tanstackField: AnyFieldApi) => (
           <FieldContext.Provider
             value={{

--- a/packages/form-react/src/form.tsx
+++ b/packages/form-react/src/form.tsx
@@ -1,4 +1,4 @@
-import type { FormEvent, FormHTMLAttributes, ReactNode } from "react";
+import type { ElementType, FormEvent, HTMLAttributes, ReactNode } from "react";
 import type {
   Field as CoreField,
   FormRegistries,
@@ -11,10 +11,13 @@ import type { FieldRegistry } from "./contexts";
 import { RenderFields } from "./renderer";
 
 /** Props for the headless `<Form>` wrapper component. */
-export interface FormProps<TFormData extends UnknownData = UnknownData>
-  extends Omit<FormHTMLAttributes<HTMLFormElement>, "onSubmit"> {
+export interface FormProps<
+  TFormData extends UnknownData = UnknownData,
+> extends Omit<HTMLAttributes<HTMLElement>, "onSubmit"> {
   /** TanStack form instance created by `useForm`. */
   form: FieldFormApi<TFormData>;
+  /** Optional component or HTML tag to render instead of 'form'. Use 'div' for nested forms. */
+  as?: ElementType;
   /** Optional schema fields to auto-render when no children are provided. */
   fields?: readonly CoreField[];
   /** External context data used by dynamic runtime checks. */
@@ -34,7 +37,7 @@ export interface FormProps<TFormData extends UnknownData = UnknownData>
   /** Optional parent data path used to resolve nested field names. */
   basePath?: string;
   /** Optional custom submit handler invoked before `form.handleSubmit()`. */
-  onSubmit?: (event: FormEvent<HTMLFormElement>) => void;
+  onSubmit?: (event: FormEvent<HTMLElement>) => void;
   /** Children to render inside the form. */
   children?: ReactNode;
 }
@@ -42,6 +45,7 @@ export interface FormProps<TFormData extends UnknownData = UnknownData>
 /** Headless form wrapper that wires submit handling and optional schema rendering. */
 export function Form<TFormData extends UnknownData = UnknownData>({
   form,
+  as: Component = "form",
   fields,
   contextData,
   registries,
@@ -55,7 +59,7 @@ export function Form<TFormData extends UnknownData = UnknownData>({
   children,
   ...rest
 }: FormProps<TFormData>) {
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (event: FormEvent<HTMLElement>) => {
     onSubmit?.(event);
     if (event.defaultPrevented) return;
     event.preventDefault();
@@ -68,15 +72,21 @@ export function Form<TFormData extends UnknownData = UnknownData>({
       ? {
           ...registries,
           fields: (registries?.fields ?? registry) as FormRegistries["fields"],
-          validators: { ...registries?.validators, ...customValidators } as FormRegistries["validators"],
-          resolvers: { ...registries?.resolvers, ...optionResolvers } as FormRegistries["resolvers"],
+          validators: {
+            ...registries?.validators,
+            ...customValidators,
+          } as FormRegistries["validators"],
+          resolvers: {
+            ...registries?.resolvers,
+            ...optionResolvers,
+          } as FormRegistries["resolvers"],
         }
       : undefined;
 
   return (
-    <form
+    <Component
       {...rest}
-      onSubmit={handleSubmit}
+      onSubmit={Component === "form" ? handleSubmit : undefined}
     >
       {children ??
         (fields ? (
@@ -90,6 +100,6 @@ export function Form<TFormData extends UnknownData = UnknownData>({
             basePath={basePath}
           />
         ) : null)}
-    </form>
+    </Component>
   );
 }

--- a/packages/form-react/src/index.ts
+++ b/packages/form-react/src/index.ts
@@ -100,6 +100,7 @@ export type {
 } from "@buildnbuzz/form-core";
 
 export { useForm } from "./use-form";
+export { useWatch } from "./use-watch";
 export { Field } from "./field";
 export { Form } from "./form";
 export { FieldRenderer, RenderFields } from "./renderer";
@@ -154,6 +155,8 @@ export type {
   FieldOptionsState,
   ResolvedFieldTextOptions,
 } from "./contexts";
+
+export { mergeRegistries } from "./utils/merge-registries";
 
 declare module "@buildnbuzz/form-core" {
   interface FrameworkOverrides {

--- a/packages/form-react/src/types.ts
+++ b/packages/form-react/src/types.ts
@@ -7,7 +7,6 @@ import type { FieldValidators } from "@tanstack/form-core";
 import type { ReactNode } from "react";
 import type {
   DataField,
-  Field as CoreField,
   FormSchema,
   FormRegistries,
   OutputConfig,

--- a/packages/form-react/src/use-watch.test.tsx
+++ b/packages/form-react/src/use-watch.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React, { type PropsWithChildren } from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useWatch } from "./use-watch";
+import { useForm } from "./use-form";
+import type { AnyReactFormExtendedApi } from "./types";
+import type { FormSchema } from "@buildnbuzz/form-core";
+
+type TestData = { name: string; age?: number };
+
+function createFormWrapper() {
+  let formRef: AnyReactFormExtendedApi<TestData> | null = null;
+
+  const Wrapper = ({ children }: PropsWithChildren) => {
+    const form = useForm<TestData>({
+      schema: { fields: [] } as unknown as FormSchema,
+      defaultValues: { name: "initial", age: 0 },
+    });
+    formRef = form;
+    return <>{children}</>;
+  };
+
+  return {
+    Wrapper,
+    getForm: () => formRef!,
+  };
+}
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("useWatch", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should not fire onChange on initial render", () => {
+    const onChange = vi.fn();
+    const { Wrapper, getForm } = createFormWrapper();
+
+    renderHook(
+      () =>
+        useWatch({
+          form: getForm(),
+          onChange,
+        }),
+      { wrapper: Wrapper },
+    );
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("should fire onChange immediately when debounceMs is 0", () => {
+    const onChange = vi.fn();
+    const { Wrapper, getForm } = createFormWrapper();
+
+    renderHook(
+      () =>
+        useWatch({
+          form: getForm(),
+          onChange,
+          debounceMs: 0,
+        }),
+      { wrapper: Wrapper },
+    );
+
+    act(() => {
+      getForm().setFieldValue("name", "changed");
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "changed" }),
+    );
+  });
+
+  it("should debounce onChange when debounceMs > 0", async () => {
+    const onChange = vi.fn();
+    const { Wrapper, getForm } = createFormWrapper();
+
+    renderHook(
+      () =>
+        useWatch({
+          form: getForm(),
+          onChange,
+          debounceMs: 50,
+        }),
+      { wrapper: Wrapper },
+    );
+
+    act(() => {
+      getForm().setFieldValue("name", "debounced");
+    });
+
+    // Not fired yet — still within debounce window
+    expect(onChange).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await wait(80);
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "debounced" }),
+    );
+  });
+
+  it("should coalesce rapid changes during debounce window", async () => {
+    const onChange = vi.fn();
+    const { Wrapper, getForm } = createFormWrapper();
+
+    renderHook(
+      () =>
+        useWatch({
+          form: getForm(),
+          onChange,
+          debounceMs: 50,
+        }),
+      { wrapper: Wrapper },
+    );
+
+    act(() => {
+      getForm().setFieldValue("name", "a");
+    });
+    act(() => {
+      getForm().setFieldValue("name", "ab");
+    });
+    act(() => {
+      getForm().setFieldValue("name", "abc");
+    });
+
+    await act(async () => {
+      await wait(80);
+    });
+
+    // Only last value fires
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "abc" }),
+    );
+  });
+
+  it("should cleanup pending timeout on unmount", async () => {
+    const onChange = vi.fn();
+    const { Wrapper, getForm } = createFormWrapper();
+
+    const { unmount } = renderHook(
+      () =>
+        useWatch({
+          form: getForm(),
+          onChange,
+          debounceMs: 100,
+        }),
+      { wrapper: Wrapper },
+    );
+
+    act(() => {
+      getForm().setFieldValue("name", "pending");
+    });
+
+    unmount();
+
+    await act(async () => {
+      await wait(150);
+    });
+
+    // Should NOT fire after unmount
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/form-react/src/use-watch.ts
+++ b/packages/form-react/src/use-watch.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from "react";
+import { useStore } from "@tanstack/react-form";
+import type { AnyReactFormExtendedApi } from "./types";
+
+export interface UseWatchOptions<TFormData> {
+  form: AnyReactFormExtendedApi<TFormData>;
+  onChange: (values: TFormData) => void;
+  debounceMs?: number;
+}
+
+export function useWatch<TFormData>({
+  form,
+  onChange,
+  debounceMs = 0,
+}: UseWatchOptions<TFormData>) {
+  const values = useStore(form.store, (state) => state.values as TFormData);
+  const isFirstRenderRef = useRef(true);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onChangeRef = useRef(onChange);
+  const debounceRef = useRef(debounceMs);
+
+  // Keep refs in sync without triggering effects
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+  useEffect(() => {
+    debounceRef.current = debounceMs;
+  }, [debounceMs]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    // Skip the initial render
+    if (isFirstRenderRef.current) {
+      isFirstRenderRef.current = false;
+      return;
+    }
+
+    const fire = () => onChangeRef.current(values);
+
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+
+    if (debounceRef.current > 0) {
+      timeoutRef.current = setTimeout(fire, debounceRef.current);
+    } else {
+      fire();
+    }
+  }, [values]); // values reference only changes when content changes — no JSON.stringify needed
+}


### PR DESCRIPTION
## Description

Add `useWatch` hook to `form-react` for easier state subscription and implement a polymorphic `as` prop on the `Form` component to allow custom rendering (e.g., using `div` for nested forms).

## Key Changes

### React Adapter (`form-react`)

- Implement `useWatch` hook with debouncing support.
- Add polymorphic `as` prop to `Form` component.
- Fix optional name handling in `Field` component pointers.
- Export `useWatch` and `mergeRegistries` from main entry point.

### Other

- Add changeset for `@buildnbuzz/form-react` (patch).

## Type of change

- [x] `feat` (New feature)

## Related Issues

- None