### PR TITLE
feat(form-builder-react): add local storage persistence

### DIFF
--- a/.changeset/form-builder-react-patch.md
+++ b/.changeset/form-builder-react-patch.md
@@ -1,0 +1,9 @@
+---
+"@buildnbuzz/form-builder-react": patch
+---
+
+Add local storage persistence for the form builder React adapter.
+
+- Persist form builder documents in local storage with a namespaced index.
+- Load, list, and remove saved documents consistently from the browser storage provider.
+- Normalize storage keys and keep index entries aligned with the saved documents.

--- a/packages/form-builder-react/src/persistence/local-storage-provider.ts
+++ b/packages/form-builder-react/src/persistence/local-storage-provider.ts
@@ -188,13 +188,23 @@ export class LocalStorageProvider implements BuilderStorageProvider {
   }
 }
 
-let browserLocalStorageProvider: LocalStorageProvider | null = null;
+const browserLocalStorageProviders = new Map<string, LocalStorageProvider>();
 
-export function getBrowserLocalStorageProvider(): LocalStorageProvider {
-  if (!browserLocalStorageProvider) {
-    browserLocalStorageProvider = new LocalStorageProvider();
+export function getBrowserLocalStorageProvider(
+  namespace?: string,
+): LocalStorageProvider {
+  const normalizedNamespace =
+    normalizeNamespace(namespace) ?? DEFAULT_NAMESPACE;
+  const existingProvider =
+    browserLocalStorageProviders.get(normalizedNamespace);
+
+  if (existingProvider) {
+    return existingProvider;
   }
-  return browserLocalStorageProvider;
+
+  const provider = new LocalStorageProvider({ namespace: normalizedNamespace });
+  browserLocalStorageProviders.set(normalizedNamespace, provider);
+  return provider;
 }
 
 function resolveStorage(storage?: Storage): Storage {


### PR DESCRIPTION
## Description

Add local storage persistence for the form builder React adapter.

## Key Changes

### Core (`form-core`)

- None.

### React Adapter (`form-react`)

- None.

### Docs / Web (`apps/web`)

- Updated the main builder entry links to point at `/builder/v2`.

### Other

- Added a patch changeset for `@buildnbuzz/form-builder-react`.
- Pushed the GitButler virtual branch `feat/form-builder-react-storage` to origin.

## Type of change

- [ ] `feat` (New feature)
- [x] `fix` (Bug fix)
- [ ] `docs` (Documentation changes)
- [ ] `refactor` (Refactoring code without changing behavior)
- [ ] `test` (Adding or updating tests)
- [ ] `chore` (Maintenance, CI/CD, or Ops-related changes)

## Related Issues

- Closes #
