### PR TITLE
feat(form-core): add serializable schema primitives and validator

### DIFF
--- a/.changeset/add-serializable-primitives.md
+++ b/.changeset/add-serializable-primitives.md
@@ -1,0 +1,11 @@
+---
+"@buildnbuzz/form-core": patch
+---
+
+feat(form-core): add serializable schema primitives, validator, and metadata
+
+- Add `SerializableFormSchema` types for headless serialization
+- Implement `validateSchema` with structure and identity checks
+- Implement `autoFixSchema` for common schema errors
+- Add `FIELD_TYPE_META` for field capability discovery
+- Export serialization utilities: `isSerializable`, `toSerializable`, `serializeSchema`

--- a/packages/form-core/src/field-meta.ts
+++ b/packages/form-core/src/field-meta.ts
@@ -17,6 +17,8 @@ export interface FieldTypeMeta {
   applicableValidators: readonly BuiltInValidatorName[];
   /** Example of a minimal valid configuration */
   example: Record<string, unknown>;
+  /** Indicates if this field can contain other fields */
+  hasChildren?: boolean;
 }
 
 export const FIELD_TYPE_META: Record<FieldType, FieldTypeMeta> = {
@@ -118,6 +120,56 @@ export const FIELD_TYPE_META: Record<FieldType, FieldTypeMeta> = {
     optionalProps: ["label", "description", "placeholder", "required", "disabled", "readOnly", "hidden", "condition", "defaultValue"],
     applicableValidators: ["required"],
     example: { type: "radio", name: "plan", label: "Plan", options: [{ label: "Basic", value: "basic" }] }
+  },
+  group: {
+    type: "group",
+    category: "container",
+    description: "Groups fields into a nested object",
+    requiredProps: ["type", "name", "fields"],
+    optionalProps: ["label", "description", "hidden", "condition", "disabled", "readOnly"],
+    applicableValidators: [],
+    example: { type: "group", name: "address", fields: [{ type: "text", name: "city" }] },
+    hasChildren: true
+  },
+  array: {
+    type: "array",
+    category: "container",
+    description: "List of items (objects or primitives)",
+    requiredProps: ["type", "name", "fields"],
+    optionalProps: ["label", "description", "hidden", "condition", "primitive", "minItems", "maxItems", "disabled", "readOnly"],
+    applicableValidators: ["minItems", "maxItems"],
+    example: { type: "array", name: "users", fields: [{ type: "text", name: "name" }] },
+    hasChildren: true
+  },
+  row: {
+    type: "row",
+    category: "layout",
+    description: "Horizontal flex layout",
+    requiredProps: ["type", "fields"],
+    optionalProps: ["hidden", "condition"],
+    applicableValidators: [],
+    example: { type: "row", fields: [{ type: "text", name: "firstName" }, { type: "text", name: "lastName" }] },
+    hasChildren: true
+  },
+  tabs: {
+    type: "tabs",
+    category: "layout",
+    description: "Tabbed container layout",
+    requiredProps: ["type", "tabs"],
+    optionalProps: ["hidden", "condition"],
+    applicableValidators: [],
+    example: { type: "tabs", tabs: [{ label: "General", fields: [] }] },
+    hasChildren: true
+  },
+  collapsible: {
+    type: "collapsible",
+    category: "layout",
+    description: "Expandable/collapsible container",
+    requiredProps: ["type", "label", "fields"],
+    optionalProps: ["hidden", "condition", "collapsed"],
+    applicableValidators: [],
+    example: { type: "collapsible", label: "Advanced", fields: [] },
+    hasChildren: true
   }
 } as unknown as Record<FieldType, FieldTypeMeta>;
 

--- a/packages/form-core/src/field-meta.ts
+++ b/packages/form-core/src/field-meta.ts
@@ -19,7 +19,71 @@ export interface FieldTypeMeta {
   example: Record<string, unknown>;
 }
 
-export const FIELD_TYPE_META: Record<FieldType, FieldTypeMeta> = {} as Record<FieldType, FieldTypeMeta>;
+export const FIELD_TYPE_META: Record<FieldType, FieldTypeMeta> = {
+  text: {
+    type: "text",
+    category: "input",
+    description: "Standard single-line text input",
+    requiredProps: ["type", "name"],
+    optionalProps: ["label", "description", "placeholder", "required", "disabled", "readOnly", "hidden", "condition", "defaultValue", "trim", "minLength", "maxLength", "pattern"],
+    applicableValidators: ["required", "minLength", "maxLength", "pattern", "matches"],
+    example: { type: "text", name: "firstName", label: "First Name" }
+  },
+  email: {
+    type: "email",
+    category: "input",
+    description: "Email address input with automatic format validation",
+    requiredProps: ["type", "name"],
+    optionalProps: ["label", "description", "placeholder", "required", "disabled", "readOnly", "hidden", "condition", "defaultValue", "minLength", "maxLength"],
+    applicableValidators: ["required", "email", "minLength", "maxLength", "matches"],
+    example: { type: "email", name: "userEmail", label: "Email Address" }
+  },
+  password: {
+    type: "password",
+    category: "input",
+    description: "Masked password input with strength criteria support",
+    requiredProps: ["type", "name"],
+    optionalProps: ["label", "description", "placeholder", "required", "disabled", "readOnly", "hidden", "condition", "defaultValue", "minLength", "maxLength", "criteria"],
+    applicableValidators: ["required", "minLength", "maxLength", "matches", "passwordCriteria"],
+    example: { type: "password", name: "newPassword", label: "Password" }
+  },
+  textarea: {
+    type: "textarea",
+    category: "input",
+    description: "Multi-line text input",
+    requiredProps: ["type", "name"],
+    optionalProps: ["label", "description", "placeholder", "required", "disabled", "readOnly", "hidden", "condition", "defaultValue", "trim", "minLength", "maxLength", "pattern"],
+    applicableValidators: ["required", "minLength", "maxLength", "pattern", "matches"],
+    example: { type: "textarea", name: "bio", label: "Biography" }
+  },
+  number: {
+    type: "number",
+    category: "input",
+    description: "Numeric input",
+    requiredProps: ["type", "name"],
+    optionalProps: ["label", "description", "placeholder", "required", "disabled", "readOnly", "hidden", "condition", "defaultValue", "min", "max", "precision", "step"],
+    applicableValidators: ["required", "min", "max", "precision", "step"],
+    example: { type: "number", name: "age", label: "Age" }
+  },
+  date: {
+    type: "date",
+    category: "input",
+    description: "Date picker, optionally with time",
+    requiredProps: ["type", "name"],
+    optionalProps: ["label", "description", "placeholder", "required", "disabled", "readOnly", "hidden", "condition", "defaultValue", "withTime", "minDate", "maxDate"],
+    applicableValidators: ["required", "minDate", "maxDate"],
+    example: { type: "date", name: "birthdate", label: "Birth Date" }
+  },
+  tags: {
+    type: "tags",
+    category: "input",
+    description: "Multi-value chip/tag input (string array)",
+    requiredProps: ["type", "name"],
+    optionalProps: ["label", "description", "placeholder", "required", "disabled", "readOnly", "hidden", "condition", "defaultValue", "minTags", "maxTags", "maxTagLength", "allowDuplicates"],
+    applicableValidators: ["required", "minTags", "maxTags"],
+    example: { type: "tags", name: "skills", label: "Skills" }
+  }
+} as unknown as Record<FieldType, FieldTypeMeta>;
 
 export function getFieldMeta(type: string): FieldTypeMeta | undefined {
   return FIELD_TYPE_META[type as FieldType];

--- a/packages/form-core/src/field-meta.ts
+++ b/packages/form-core/src/field-meta.ts
@@ -1,0 +1,30 @@
+import type { FieldType, BuiltInValidatorName } from "./types";
+
+export type FieldCategory = "input" | "choice" | "container" | "layout";
+
+export interface FieldTypeMeta {
+  /** The field type identifier */
+  type: FieldType;
+  /** Broad category for UI grouping */
+  category: FieldCategory;
+  /** Human readable description of what the field is for */
+  description: string;
+  /** Properties that are always required when defining this field */
+  requiredProps: readonly string[];
+  /** Optional properties supported by this field */
+  optionalProps: readonly string[];
+  /** Supported built-in validators */
+  applicableValidators: readonly BuiltInValidatorName[];
+  /** Example of a minimal valid configuration */
+  example: Record<string, unknown>;
+}
+
+export const FIELD_TYPE_META: Record<FieldType, FieldTypeMeta> = {} as Record<FieldType, FieldTypeMeta>;
+
+export function getFieldMeta(type: string): FieldTypeMeta | undefined {
+  return FIELD_TYPE_META[type as FieldType];
+}
+
+export function getFieldsByCategory(category: FieldCategory): FieldTypeMeta[] {
+  return Object.values(FIELD_TYPE_META).filter((meta) => meta && meta.category === category);
+}

--- a/packages/form-core/src/field-meta.ts
+++ b/packages/form-core/src/field-meta.ts
@@ -1,7 +1,9 @@
 import type { FieldType, BuiltInValidatorName } from "./types";
 
+/** Broad category for UI grouping and organization */
 export type FieldCategory = "input" | "choice" | "container" | "layout";
 
+/** Metadata describing a field type and its capabilities */
 export interface FieldTypeMeta {
   /** The field type identifier */
   type: FieldType;
@@ -21,6 +23,10 @@ export interface FieldTypeMeta {
   hasChildren?: boolean;
 }
 
+/** 
+ * Registry of metadata for all supported field types.
+ * @internal
+ */
 export const FIELD_TYPE_META: Record<FieldType, FieldTypeMeta> = {
   text: {
     type: "text",
@@ -171,12 +177,18 @@ export const FIELD_TYPE_META: Record<FieldType, FieldTypeMeta> = {
     example: { type: "collapsible", label: "Advanced", fields: [] },
     hasChildren: true
   }
-} as unknown as Record<FieldType, FieldTypeMeta>;
+};
 
+/** 
+ * Retrieves metadata for a specific field type.
+ */
 export function getFieldMeta(type: string): FieldTypeMeta | undefined {
   return FIELD_TYPE_META[type as FieldType];
 }
 
+/** 
+ * Retrieves all field types within a specific category.
+ */
 export function getFieldsByCategory(category: FieldCategory): FieldTypeMeta[] {
   return Object.values(FIELD_TYPE_META).filter((meta) => meta && meta.category === category);
 }

--- a/packages/form-core/src/field-meta.ts
+++ b/packages/form-core/src/field-meta.ts
@@ -82,6 +82,42 @@ export const FIELD_TYPE_META: Record<FieldType, FieldTypeMeta> = {
     optionalProps: ["label", "description", "placeholder", "required", "disabled", "readOnly", "hidden", "condition", "defaultValue", "minTags", "maxTags", "maxTagLength", "allowDuplicates"],
     applicableValidators: ["required", "minTags", "maxTags"],
     example: { type: "tags", name: "skills", label: "Skills" }
+  },
+  select: {
+    type: "select",
+    category: "choice",
+    description: "Dropdown selection (single or multi-select via hasMany)",
+    requiredProps: ["type", "name", "options"],
+    optionalProps: ["label", "description", "placeholder", "required", "disabled", "readOnly", "hidden", "condition", "defaultValue", "hasMany", "minSelected", "maxSelected"],
+    applicableValidators: ["required", "minSelected", "maxSelected"],
+    example: { type: "select", name: "country", label: "Country", options: [{ label: "USA", value: "us" }] }
+  },
+  checkbox: {
+    type: "checkbox",
+    category: "choice",
+    description: "Checkbox input (single boolean, tristate boolean, or multi-select group via hasMany)",
+    requiredProps: ["type", "name"],
+    optionalProps: ["label", "description", "placeholder", "required", "disabled", "readOnly", "hidden", "condition", "defaultValue", "hasMany", "tristate", "options", "minSelected", "maxSelected"],
+    applicableValidators: ["required", "minSelected", "maxSelected"],
+    example: { type: "checkbox", name: "terms", label: "Accept Terms" }
+  },
+  switch: {
+    type: "switch",
+    category: "choice",
+    description: "Toggle switch (boolean)",
+    requiredProps: ["type", "name"],
+    optionalProps: ["label", "description", "placeholder", "required", "disabled", "readOnly", "hidden", "condition", "defaultValue"],
+    applicableValidators: ["required"],
+    example: { type: "switch", name: "notifications", label: "Enable Notifications" }
+  },
+  radio: {
+    type: "radio",
+    category: "choice",
+    description: "Radio button group for single selection",
+    requiredProps: ["type", "name", "options"],
+    optionalProps: ["label", "description", "placeholder", "required", "disabled", "readOnly", "hidden", "condition", "defaultValue"],
+    applicableValidators: ["required"],
+    example: { type: "radio", name: "plan", label: "Plan", options: [{ label: "Basic", value: "basic" }] }
   }
 } as unknown as Record<FieldType, FieldTypeMeta>;
 

--- a/packages/form-core/src/index.ts
+++ b/packages/form-core/src/index.ts
@@ -15,4 +15,11 @@ export * from "./validation";
 export * from "./serializable";
 export * from "./field-meta";
 export * from "./schema-fixer";
-export { validateSchema as validateSerializableSchema, formatSchemaIssues } from "./schema-validator";
+export { 
+  validateSchema as validateSerializableSchema, 
+  formatSchemaIssues,
+  type SchemaIssue,
+  type SchemaIssueCode,
+  type SchemaIssueSeverity,
+  type SchemaValidationResult
+} from "./schema-validator";

--- a/packages/form-core/src/index.ts
+++ b/packages/form-core/src/index.ts
@@ -12,3 +12,7 @@ export * from "./utils/dependencies";
 export * from "./utils/output";
 export * from "./utils/number";
 export * from "./validation";
+export * from "./serializable";
+export * from "./field-meta";
+export * from "./schema-fixer";
+export { validateSchema as validateSerializableSchema, formatSchemaIssues } from "./schema-validator";

--- a/packages/form-core/src/schema-fixer.ts
+++ b/packages/form-core/src/schema-fixer.ts
@@ -1,0 +1,86 @@
+import type { SerializableFormSchema, SerializableField } from "./serializable";
+import { FIELD_TYPE_META } from "./field-meta";
+
+/**
+ * Applies heuristics to fix common AI generation mistakes in a form schema.
+ * Returns a new schema with fixes applied.
+ */
+export function autoFixSchema(schema: SerializableFormSchema): SerializableFormSchema {
+  return {
+    ...schema,
+    fields: Array.isArray(schema.fields) ? schema.fields.map(fixField) : [],
+  };
+}
+
+type MutableField = {
+  type?: string;
+  name?: string;
+  label?: string;
+  fields?: unknown[];
+  tabs?: { fields?: unknown[]; [key: string]: unknown }[];
+  [key: string]: unknown;
+};
+
+function fixField(field: SerializableField): SerializableField {
+  // Deep clone the field object
+  const f = JSON.parse(JSON.stringify(field)) as MutableField;
+
+  // 1. Normalize type casing (e.g. "Text" -> "text")
+  if (f.type && typeof f.type === "string") {
+    const lowerType = f.type.toLowerCase();
+    if (lowerType !== f.type && FIELD_TYPE_META[lowerType as keyof typeof FIELD_TYPE_META]) {
+      f.type = lowerType;
+    }
+  }
+
+  const isLayout = ["row", "tabs", "collapsible"].includes(f.type || "");
+  const isContainer = ["group", "array", "row", "collapsible"].includes(f.type || "");
+
+  // 2. Remove name from layout fields
+  if (isLayout && "name" in f) {
+    delete f.name;
+  }
+
+  // 3. Generate name from label if missing
+  if (!isLayout && (!f.name || typeof f.name !== "string" || f.name.trim() === "")) {
+    if (f.label && typeof f.label === "string" && f.label.trim() !== "") {
+      f.name = toCamelCase(f.label);
+    }
+  }
+
+  // 4. Add missing fields array to containers
+  if (isContainer) {
+    if (!Array.isArray(f.fields)) {
+      f.fields = [];
+    } else {
+      f.fields = f.fields.map((child) => fixField(child as SerializableField));
+    }
+  }
+
+  // 5. Add missing tabs array to tabs
+  if (f.type === "tabs") {
+    if (!Array.isArray(f.tabs)) {
+      f.tabs = [];
+    } else {
+      f.tabs = f.tabs.map((tab) => ({
+        ...tab,
+        fields: Array.isArray(tab.fields) ? tab.fields.map((child) => fixField(child as SerializableField)) : []
+      }));
+    }
+  }
+
+  return f as unknown as SerializableField;
+}
+
+/**
+ * Converts a string like "First Name*" to "firstName"
+ */
+function toCamelCase(str: string): string {
+  const words = str.match(/[a-zA-Z0-9]+/g) || [];
+  if (words.length === 0) return "field";
+  
+  return words.map((word, index) => {
+    if (index === 0) return word.toLowerCase();
+    return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+  }).join('');
+}

--- a/packages/form-core/src/schema-fixer.ts
+++ b/packages/form-core/src/schema-fixer.ts
@@ -23,7 +23,9 @@ type MutableField = {
 
 function fixField(field: SerializableField): SerializableField {
   // Deep clone the field object
-  const f = JSON.parse(JSON.stringify(field)) as MutableField;
+  const f = (typeof structuredClone === "function" 
+    ? structuredClone(field) 
+    : JSON.parse(JSON.stringify(field))) as MutableField;
 
   // 1. Normalize type casing (e.g. "Text" -> "text")
   if (f.type && typeof f.type === "string") {

--- a/packages/form-core/src/schema-validator.ts
+++ b/packages/form-core/src/schema-validator.ts
@@ -1,4 +1,5 @@
 import type { SerializableFormSchema, SerializableField } from "./serializable";
+import { getFieldMeta } from "./field-meta";
 
 export type SchemaIssueSeverity = "error" | "warning";
 
@@ -47,6 +48,25 @@ export function validateSchema(schema: SerializableFormSchema): SchemaValidation
       
       const path = pathPrefix ? `${pathPrefix}[${index}]` : `fields[${index}]`;
       const isLayout = ["row", "tabs", "collapsible"].includes(field.type);
+
+      const meta = getFieldMeta(field.type);
+      if (!meta) {
+        issues.push({
+          code: "invalid_field_type",
+          severity: "error",
+          path,
+          message: `Unrecognized field type '${field.type}'.`
+        });
+      }
+
+      if (isLayout && "name" in field && (field as { name?: unknown }).name !== undefined) {
+        issues.push({
+          code: "name_in_layout",
+          severity: "error",
+          path,
+          message: `Layout field of type '${field.type}' must not have a 'name' property.`
+        });
+      }
 
       if (!isLayout) {
         const name = (field as { name?: unknown }).name;

--- a/packages/form-core/src/schema-validator.ts
+++ b/packages/form-core/src/schema-validator.ts
@@ -70,6 +70,59 @@ export function validateSchema(schema: SerializableFormSchema): SchemaValidation
         }
       }
 
+      const structField = field as { options?: unknown; hasMany?: unknown; fields?: unknown; primitive?: unknown; tabs?: unknown };
+
+      if (["select", "radio"].includes(field.type) || (field.type === "checkbox" && structField.hasMany)) {
+        if (!Array.isArray(structField.options) || structField.options.length === 0) {
+          issues.push({
+            code: "missing_options",
+            severity: "error",
+            path,
+            message: `Field of type '${field.type}' must have an 'options' array with at least one item.`
+          });
+        }
+      }
+
+      if (["group", "row", "array", "collapsible"].includes(field.type)) {
+        if (!Array.isArray(structField.fields)) {
+          issues.push({
+            code: "missing_fields",
+            severity: "error",
+            path,
+            message: `Container field of type '${field.type}' must have a 'fields' array.`
+          });
+        } else if (field.type === "array" && structField.primitive && structField.fields.length !== 1) {
+          issues.push({
+            code: "primitive_array_multi",
+            severity: "error",
+            path,
+            message: `Primitive array must have exactly one item in its 'fields' array.`
+          });
+        }
+      }
+
+      if (field.type === "tabs") {
+        if (!Array.isArray(structField.tabs) || structField.tabs.length === 0) {
+          issues.push({
+            code: "empty_tabs",
+            severity: "error",
+            path,
+            message: `Tabs field must have a 'tabs' array with at least one item.`
+          });
+        } else {
+          structField.tabs.forEach((tab: { fields?: unknown }, tIndex: number) => {
+            if (!tab || typeof tab !== "object" || !Array.isArray(tab.fields)) {
+              issues.push({
+                code: "missing_fields",
+                severity: "error",
+                path: `${path}.tabs[${tIndex}]`,
+                message: `Tab item must have a 'fields' array.`
+              });
+            }
+          });
+        }
+      }
+
       const containerField = field as { fields?: unknown; primitive?: unknown; tabs?: unknown };
 
       if ("fields" in field && Array.isArray(containerField.fields)) {

--- a/packages/form-core/src/schema-validator.ts
+++ b/packages/form-core/src/schema-validator.ts
@@ -1,4 +1,4 @@
-import type { SerializableFormSchema } from "./serializable";
+import type { SerializableFormSchema, SerializableField } from "./serializable";
 
 export type SchemaIssueSeverity = "error" | "warning";
 
@@ -38,7 +38,57 @@ export interface SchemaValidationResult {
 export function validateSchema(schema: SerializableFormSchema): SchemaValidationResult {
   const issues: SchemaIssue[] = [];
 
-  // Scaffolding: full implementation in subsequent tasks.
+  function validateFields(fields: readonly SerializableField[], pathPrefix: string, isPrimitiveItem = false) {
+    if (!Array.isArray(fields)) return;
+    const seenNames = new Set<string>();
+
+    fields.forEach((field, index) => {
+      if (!field || typeof field !== "object") return;
+      
+      const path = pathPrefix ? `${pathPrefix}[${index}]` : `fields[${index}]`;
+      const isLayout = ["row", "tabs", "collapsible"].includes(field.type);
+
+      if (!isLayout) {
+        const name = (field as { name?: unknown }).name;
+        if (!isPrimitiveItem && (!name || typeof name !== "string" || name.trim() === "")) {
+          issues.push({
+            code: "missing_name",
+            severity: "error",
+            path,
+            message: `Data field of type '${field.type}' must have a non-empty name.`
+          });
+        } else if (name && typeof name === "string") {
+          if (seenNames.has(name)) {
+            issues.push({
+              code: "duplicate_name",
+              severity: "error",
+              path,
+              message: `Duplicate field name '${name}' at same nesting level.`
+            });
+          }
+          seenNames.add(name);
+        }
+      }
+
+      const containerField = field as { fields?: unknown; primitive?: unknown; tabs?: unknown };
+
+      if ("fields" in field && Array.isArray(containerField.fields)) {
+        if (field.type === "array" && containerField.primitive) {
+          validateFields(containerField.fields as readonly SerializableField[], `${path}.fields`, true);
+        } else {
+          validateFields(containerField.fields as readonly SerializableField[], `${path}.fields`, false);
+        }
+      }
+
+      if (field.type === "tabs" && "tabs" in field && Array.isArray(containerField.tabs)) {
+        containerField.tabs.forEach((tab: { fields?: unknown }, tIndex: number) => {
+          validateFields((tab.fields as readonly SerializableField[]) || [], `${path}.tabs[${tIndex}].fields`, false);
+        });
+      }
+    });
+  }
+
+  validateFields(schema.fields, "");
 
   return {
     valid: issues.every((issue) => issue.severity !== "error"),

--- a/packages/form-core/src/schema-validator.ts
+++ b/packages/form-core/src/schema-validator.ts
@@ -1,8 +1,10 @@
 import type { SerializableFormSchema, SerializableField } from "./serializable";
 import { getFieldMeta } from "./field-meta";
 
+/** Severity of a schema validation issue */
 export type SchemaIssueSeverity = "error" | "warning";
 
+/** Taxonomy of schema validation errors and warnings */
 export type SchemaIssueCode =
   // Field identity
   | "missing_name"
@@ -20,16 +22,23 @@ export type SchemaIssueCode =
   | "invalid_validation"
   | "orphaned_resolver";
 
+/** A single validation issue found in the schema */
 export interface SchemaIssue {
+  /** The type of issue */
   code: SchemaIssueCode;
+  /** Whether the issue is critical (error) or informational (warning) */
   severity: SchemaIssueSeverity;
   /** Dot-separated path to the field or property */
   path: string;
+  /** Human-readable description of the issue */
   message: string;
 }
 
+/** Result of a schema validation operation */
 export interface SchemaValidationResult {
+  /** True if no issues with 'error' severity were found */
   valid: boolean;
+  /** List of all issues found during validation */
   issues: SchemaIssue[];
 }
 
@@ -90,7 +99,16 @@ export function validateSchema(schema: SerializableFormSchema): SchemaValidation
         }
       }
 
-      const structField = field as { options?: unknown; hasMany?: unknown; fields?: unknown; primitive?: unknown; tabs?: unknown };
+      const structField = field as { 
+        options?: unknown; 
+        hasMany?: unknown; 
+        fields?: unknown; 
+        primitive?: unknown; 
+        tabs?: unknown;
+        condition?: unknown;
+        validations?: unknown;
+        optionsResolver?: unknown;
+      };
 
       if (["select", "radio"].includes(field.type) || (field.type === "checkbox" && structField.hasMany)) {
         if (!Array.isArray(structField.options) || structField.options.length === 0) {
@@ -143,24 +161,25 @@ export function validateSchema(schema: SerializableFormSchema): SchemaValidation
         }
       }
 
-      const containerField = field as { fields?: unknown; primitive?: unknown; tabs?: unknown };
+      if ("condition" in field && structField.condition !== undefined) {
+        const cond = structField.condition;
+        // Conditions can be boolean, atomic object, array of objects, or group object
+        const isObject = typeof cond === "object" && cond !== null && !Array.isArray(cond);
+        const isArray = Array.isArray(cond);
+        const isBoolean = typeof cond === "boolean";
 
-      const exprField = field as { condition?: unknown; validations?: unknown; optionsResolver?: unknown };
-
-      if ("condition" in field && exprField.condition !== undefined) {
-        const cond = exprField.condition;
-        if (typeof cond !== "object" || cond === null || Array.isArray(cond)) {
+        if (!isObject && !isArray && !isBoolean) {
           issues.push({
             code: "invalid_condition",
             severity: "error",
             path: `${path}.condition`,
-            message: `Condition must be an object representing an expression.`
+            message: `Condition must be a boolean or an expression object/array.`
           });
         }
       }
 
-      if ("validations" in field && Array.isArray(exprField.validations)) {
-        exprField.validations.forEach((v: { type?: unknown } | null | undefined, vIndex: number) => {
+      if ("validations" in field && Array.isArray(structField.validations)) {
+        structField.validations.forEach((v: { type?: unknown } | null | undefined, vIndex: number) => {
           if (!v || typeof v !== "object" || typeof v.type !== "string") {
             issues.push({
               code: "invalid_validation",
@@ -181,7 +200,7 @@ export function validateSchema(schema: SerializableFormSchema): SchemaValidation
         });
       }
 
-      if ("optionsResolver" in field && exprField.optionsResolver !== undefined) {
+      if ("optionsResolver" in field && structField.optionsResolver !== undefined) {
         issues.push({
           code: "orphaned_resolver",
           severity: "warning",
@@ -190,16 +209,16 @@ export function validateSchema(schema: SerializableFormSchema): SchemaValidation
         });
       }
 
-      if ("fields" in field && Array.isArray(containerField.fields)) {
-        if (field.type === "array" && containerField.primitive) {
-          validateFields(containerField.fields as readonly SerializableField[], `${path}.fields`, true);
+      if ("fields" in field && Array.isArray(structField.fields)) {
+        if (field.type === "array" && structField.primitive) {
+          validateFields(structField.fields as readonly SerializableField[], `${path}.fields`, true);
         } else {
-          validateFields(containerField.fields as readonly SerializableField[], `${path}.fields`, false);
+          validateFields(structField.fields as readonly SerializableField[], `${path}.fields`, false);
         }
       }
 
-      if (field.type === "tabs" && "tabs" in field && Array.isArray(containerField.tabs)) {
-        containerField.tabs.forEach((tab: { fields?: unknown }, tIndex: number) => {
+      if (field.type === "tabs" && "tabs" in field && Array.isArray(structField.tabs)) {
+        structField.tabs.forEach((tab: { fields?: unknown }, tIndex: number) => {
           validateFields((tab.fields as readonly SerializableField[]) || [], `${path}.tabs[${tIndex}].fields`, false);
         });
       }

--- a/packages/form-core/src/schema-validator.ts
+++ b/packages/form-core/src/schema-validator.ts
@@ -145,6 +145,51 @@ export function validateSchema(schema: SerializableFormSchema): SchemaValidation
 
       const containerField = field as { fields?: unknown; primitive?: unknown; tabs?: unknown };
 
+      const exprField = field as { condition?: unknown; validations?: unknown; optionsResolver?: unknown };
+
+      if ("condition" in field && exprField.condition !== undefined) {
+        const cond = exprField.condition;
+        if (typeof cond !== "object" || cond === null || Array.isArray(cond)) {
+          issues.push({
+            code: "invalid_condition",
+            severity: "error",
+            path: `${path}.condition`,
+            message: `Condition must be an object representing an expression.`
+          });
+        }
+      }
+
+      if ("validations" in field && Array.isArray(exprField.validations)) {
+        exprField.validations.forEach((v: { type?: unknown } | null | undefined, vIndex: number) => {
+          if (!v || typeof v !== "object" || typeof v.type !== "string") {
+            issues.push({
+              code: "invalid_validation",
+              severity: "error",
+              path: `${path}.validations[${vIndex}]`,
+              message: `Validation must be an object with a 'type' string property.`
+            });
+            return;
+          }
+          if (v.type !== "custom" && meta && !(meta.applicableValidators as readonly string[]).includes(v.type)) {
+            issues.push({
+              code: "invalid_validation",
+              severity: "error",
+              path: `${path}.validations[${vIndex}]`,
+              message: `Validation type '${v.type}' is not applicable to field type '${field.type}'.`
+            });
+          }
+        });
+      }
+
+      if ("optionsResolver" in field && exprField.optionsResolver !== undefined) {
+        issues.push({
+          code: "orphaned_resolver",
+          severity: "warning",
+          path: `${path}.optionsResolver`,
+          message: `Dynamic option resolvers should be evaluated before AI serialization.`
+        });
+      }
+
       if ("fields" in field && Array.isArray(containerField.fields)) {
         if (field.type === "array" && containerField.primitive) {
           validateFields(containerField.fields as readonly SerializableField[], `${path}.fields`, true);

--- a/packages/form-core/src/schema-validator.ts
+++ b/packages/form-core/src/schema-validator.ts
@@ -1,0 +1,57 @@
+import type { SerializableFormSchema } from "./serializable";
+
+export type SchemaIssueSeverity = "error" | "warning";
+
+export type SchemaIssueCode =
+  // Field identity
+  | "missing_name"
+  | "duplicate_name"
+  // Structure
+  | "missing_options"
+  | "missing_fields"
+  | "empty_tabs"
+  | "primitive_array_multi"
+  // Type
+  | "invalid_field_type"
+  | "name_in_layout"
+  // Expression
+  | "invalid_condition"
+  | "invalid_validation"
+  | "orphaned_resolver";
+
+export interface SchemaIssue {
+  code: SchemaIssueCode;
+  severity: SchemaIssueSeverity;
+  /** Dot-separated path to the field or property */
+  path: string;
+  message: string;
+}
+
+export interface SchemaValidationResult {
+  valid: boolean;
+  issues: SchemaIssue[];
+}
+
+/**
+ * Validates a SerializableFormSchema for structural and semantic correctness.
+ */
+export function validateSchema(schema: SerializableFormSchema): SchemaValidationResult {
+  const issues: SchemaIssue[] = [];
+
+  // Scaffolding: full implementation in subsequent tasks.
+
+  return {
+    valid: issues.every((issue) => issue.severity !== "error"),
+    issues,
+  };
+}
+
+/**
+ * Formats a list of schema issues into human-readable strings.
+ */
+export function formatSchemaIssues(issues: SchemaIssue[]): string[] {
+  return issues.map((issue) => {
+    const prefix = issue.severity === "error" ? "❌ Error" : "⚠️ Warning";
+    return `${prefix} [${issue.code}] at ${issue.path || "root"}: ${issue.message}`;
+  });
+}

--- a/packages/form-core/src/serializable.ts
+++ b/packages/form-core/src/serializable.ts
@@ -1,0 +1,311 @@
+import type { DataPath, ContextPath, UnknownData, OptionResolverConfig } from "./types";
+
+// ============================================================================
+// Expressions & Conditions
+// ============================================================================
+
+export type SerializableExpr<T> =
+  | Exclude<T, (...args: never[]) => unknown>
+  | { $data: DataPath }
+  | { $context: ContextPath }
+  | { $args: string }
+  | { $when: SerializableCondition; $then: SerializableExpr<T>; $else: SerializableExpr<T> }
+  | { $fn: string; args?: Record<string, SerializableExpr<unknown>> }
+  | { $text: string };
+
+type ComparisonOperators = {
+  eq?: SerializableExpr<unknown>;
+  neq?: SerializableExpr<unknown>;
+  gt?: SerializableExpr<number>;
+  gte?: SerializableExpr<number>;
+  lt?: SerializableExpr<number>;
+  lte?: SerializableExpr<number>;
+  contains?: SerializableExpr<string>;
+  startsWith?: SerializableExpr<string>;
+  endsWith?: SerializableExpr<string>;
+  not?: true;
+};
+
+export type SerializableDataCondition = { $data: DataPath } & ComparisonOperators;
+export type SerializableContextCondition = { $context: ContextPath } & ComparisonOperators;
+export type SerializableAtomicCondition = SerializableDataCondition | SerializableContextCondition;
+
+export type SerializableConditionGroup =
+  | { $and: SerializableCondition[] }
+  | { $or: SerializableCondition[] };
+
+export type SerializableCondition =
+  | boolean
+  | SerializableAtomicCondition
+  | readonly SerializableAtomicCondition[]
+  | SerializableConditionGroup;
+
+export type SerializableExprBoolean = SerializableExpr<boolean> | SerializableCondition;
+export type SerializableExprString = SerializableExpr<string>;
+export type SerializableExprText = SerializableExpr<string>;
+export type SerializableExprNumber = SerializableExpr<number>;
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+export type SerializableValidationCheck = {
+  type: string;
+  message: SerializableExprText;
+  args?: Record<string, unknown>;
+};
+
+export interface SerializableValidationGroup {
+  checks: SerializableValidationCheck[];
+  debounceMs?: number;
+}
+
+export interface SerializableValidationConfig {
+  onChange?: SerializableValidationGroup;
+  onBlur?: SerializableValidationGroup;
+  onSubmit?: SerializableValidationGroup;
+}
+
+// ============================================================================
+// Options
+// ============================================================================
+
+export interface SerializableFieldOption<TValue = string> {
+  label: SerializableExprText;
+  value: TValue;
+  disabled?: SerializableExprBoolean;
+  ui?: UnknownData;
+}
+
+export type SerializableOptionsConfig =
+  | Array<SerializableFieldOption<string> | string>
+  | OptionResolverConfig;
+
+// ============================================================================
+// Base Field
+// ============================================================================
+
+export interface SerializableBaseField<TValue = unknown> {
+  name: string;
+  id?: string;
+
+  label?: SerializableExprText;
+  description?: SerializableExprText;
+  placeholder?: SerializableExprString;
+
+  required?: SerializableExprBoolean;
+  disabled?: SerializableExprBoolean;
+  readOnly?: SerializableExprBoolean;
+  hidden?: SerializableExprBoolean;
+  condition?: SerializableExprBoolean;
+
+  defaultValue?: SerializableExpr<TValue>;
+
+  validate?: SerializableValidationConfig;
+  dependencies?: DataPath[];
+  autoComplete?: string;
+
+  meta?: UnknownData;
+  ui?: UnknownData;
+}
+
+// ============================================================================
+// Data Fields
+// ============================================================================
+
+export interface SerializableTextField extends SerializableBaseField<string> {
+  type: "text";
+  trim?: boolean;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+}
+
+export interface SerializableEmailField extends SerializableBaseField<string> {
+  type: "email";
+  minLength?: number;
+  maxLength?: number;
+}
+
+export interface SerializablePasswordCriteria {
+  requireUppercase?: boolean;
+  requireLowercase?: boolean;
+  requireNumber?: boolean;
+  requireSpecial?: boolean;
+}
+
+export interface SerializablePasswordField extends SerializableBaseField<string> {
+  type: "password";
+  minLength?: number;
+  maxLength?: number;
+  criteria?: SerializablePasswordCriteria;
+}
+
+export interface SerializableTextareaField extends SerializableBaseField<string> {
+  type: "textarea";
+  trim?: boolean;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+}
+
+export interface SerializableNumberField extends SerializableBaseField<number> {
+  type: "number";
+  min?: number;
+  max?: number;
+  precision?: number;
+  step?: number;
+}
+
+export interface SerializableSelectField extends SerializableBaseField<string | string[]> {
+  type: "select";
+  options: SerializableOptionsConfig;
+  hasMany?: boolean;
+  minSelected?: number;
+  maxSelected?: number;
+}
+
+export interface SerializableDateField extends SerializableBaseField<string> {
+  type: "date";
+  withTime?: boolean;
+  minDate?: string;
+  maxDate?: string;
+}
+
+export interface SerializableTagsField extends SerializableBaseField<string[]> {
+  type: "tags";
+  minTags?: number;
+  maxTags?: number;
+  maxTagLength?: number;
+  allowDuplicates?: boolean;
+}
+
+export interface SerializableCheckboxField extends SerializableBaseField<boolean> {
+  type: "checkbox";
+  hasMany?: false;
+  tristate?: false;
+}
+
+export interface SerializableTristateCheckboxField extends SerializableBaseField<boolean | null> {
+  type: "checkbox";
+  hasMany?: false;
+  tristate: true;
+}
+
+export interface SerializableCheckboxGroupField extends SerializableBaseField<string[]> {
+  type: "checkbox";
+  hasMany: true;
+  options: SerializableOptionsConfig;
+  minSelected?: number;
+  maxSelected?: number;
+}
+
+export interface SerializableSwitchField extends SerializableBaseField<boolean> {
+  type: "switch";
+}
+
+export interface SerializableRadioField extends SerializableBaseField<string> {
+  type: "radio";
+  options: SerializableOptionsConfig;
+}
+
+export interface SerializableGroupField extends SerializableBaseField<UnknownData> {
+  type: "group";
+  fields: readonly SerializableField[];
+}
+
+export interface SerializableArrayField extends SerializableBaseField<unknown[]> {
+  type: "array";
+  primitive?: false;
+  fields: readonly SerializableField[];
+  minItems?: number;
+  maxItems?: number;
+}
+
+export type SerializablePrimitiveDataField = Exclude<
+  SerializableDataField,
+  SerializableGroupField | SerializableArrayField | SerializablePrimitiveArrayField
+>;
+
+export type SerializablePrimitiveArrayItemField = Omit<SerializablePrimitiveDataField, "name"> & { name?: string };
+
+export interface SerializablePrimitiveArrayField extends SerializableBaseField<unknown[]> {
+  type: "array";
+  primitive: true;
+  fields: readonly [SerializablePrimitiveArrayItemField];
+  minItems?: number;
+  maxItems?: number;
+}
+
+export type SerializableDataField =
+  | SerializableTextField
+  | SerializableEmailField
+  | SerializablePasswordField
+  | SerializableTextareaField
+  | SerializableNumberField
+  | SerializableSelectField
+  | SerializableDateField
+  | SerializableTagsField
+  | SerializableCheckboxField
+  | SerializableTristateCheckboxField
+  | SerializableCheckboxGroupField
+  | SerializableSwitchField
+  | SerializableRadioField
+  | SerializableGroupField
+  | SerializableArrayField
+  | SerializablePrimitiveArrayField;
+
+// ============================================================================
+// Layout Fields
+// ============================================================================
+
+export interface SerializableBaseLayoutField {
+  hidden?: SerializableExprBoolean;
+  condition?: SerializableExprBoolean;
+  meta?: UnknownData;
+  ui?: UnknownData;
+}
+
+export interface SerializableRowField extends SerializableBaseLayoutField {
+  type: "row";
+  fields: readonly SerializableField[];
+}
+
+export interface SerializableTab {
+  name?: string;
+  label: SerializableExprText;
+  fields: readonly SerializableField[];
+  disabled?: SerializableExprBoolean;
+}
+
+export interface SerializableTabsField extends SerializableBaseLayoutField {
+  type: "tabs";
+  tabs: readonly SerializableTab[];
+}
+
+export interface SerializableCollapsibleField extends SerializableBaseLayoutField {
+  type: "collapsible";
+  label: SerializableExprText;
+  fields: readonly SerializableField[];
+  collapsed?: SerializableExprBoolean;
+}
+
+export type SerializableLayoutField =
+  | SerializableRowField
+  | SerializableTabsField
+  | SerializableCollapsibleField;
+
+export type SerializableField = SerializableDataField | SerializableLayoutField;
+
+// ============================================================================
+// Root Schema
+// ============================================================================
+
+export interface SerializableFormSchema {
+  id?: string;
+  title?: string;
+  description?: string;
+  fields: readonly SerializableField[];
+  validate?: SerializableValidationConfig;
+  meta?: UnknownData;
+}

--- a/packages/form-core/src/serializable.ts
+++ b/packages/form-core/src/serializable.ts
@@ -371,3 +371,46 @@ export function toSerializable(schema: FormSchema): SerializableFormSchema {
 
   return transform(schema) as SerializableFormSchema;
 }
+
+export function serializeSchema(schema: SerializableFormSchema): string {
+  const deterministicStringify = (val: unknown): string | undefined => {
+    if (val === null) return "null";
+    if (typeof val !== "object") return JSON.stringify(val);
+    if (Array.isArray(val)) {
+      return "[" + val.map((v) => deterministicStringify(v) ?? "null").join(",") + "]";
+    }
+    const keys = Object.keys(val as Record<string, unknown>).sort();
+    let str = "{";
+    let first = true;
+    for (const k of keys) {
+      const v = (val as Record<string, unknown>)[k];
+      if (v !== undefined) {
+        const vStr = deterministicStringify(v);
+        if (vStr !== undefined) {
+          if (!first) str += ",";
+          str += JSON.stringify(k) + ":" + vStr;
+          first = false;
+        }
+      }
+    }
+    str += "}";
+    return str;
+  };
+
+  return deterministicStringify(schema) || "{}";
+}
+
+export function deserializeSchema(json: string): SerializableFormSchema {
+  try {
+    const parsed = JSON.parse(json);
+    if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.fields)) {
+      throw new Error("Invalid schema structure: missing 'fields' array");
+    }
+    return parsed as SerializableFormSchema;
+  } catch (err) {
+    if (err instanceof Error && err.message !== "Invalid schema structure: missing 'fields' array") {
+      throw new Error(`Failed to parse schema: ${err.message}`);
+    }
+    throw err;
+  }
+}

--- a/packages/form-core/src/serializable.ts
+++ b/packages/form-core/src/serializable.ts
@@ -309,3 +309,65 @@ export interface SerializableFormSchema {
   validate?: SerializableValidationConfig;
   meta?: UnknownData;
 }
+
+import type { FormSchema } from "./types";
+
+export function isSerializable(schema: FormSchema): schema is SerializableFormSchema {
+  let valid = true;
+  const walk = (val: unknown) => {
+    if (!valid) return;
+    if (typeof val === "function") {
+      valid = false;
+      return;
+    }
+    if (val !== null && typeof val === "object") {
+      if (typeof (val as { $$typeof?: unknown }).$$typeof === "symbol") {
+        valid = false;
+        return;
+      }
+      if (Array.isArray(val)) {
+        for (const item of val) walk(item);
+      } else {
+        for (const key in val) {
+          if (Object.prototype.hasOwnProperty.call(val, key)) {
+            walk((val as Record<string, unknown>)[key]);
+          }
+        }
+      }
+    }
+  };
+  walk(schema);
+  return valid;
+}
+
+export function toSerializable(schema: FormSchema): SerializableFormSchema {
+  const transform = (val: unknown, key?: string): unknown => {
+    if (typeof val === "function") {
+      if (key === "options") return [];
+      return undefined;
+    }
+    if (val === null || typeof val !== "object") return val;
+    
+    if (typeof (val as { $$typeof?: unknown }).$$typeof === "symbol") {
+      return String(val);
+    }
+
+    if (Array.isArray(val)) {
+      // Don't pass 'key' to array items to avoid treating functions in arrays as 'options' incorrectly
+      return val.map((v) => transform(v));
+    }
+
+    const out: Record<string, unknown> = {};
+    for (const k in val) {
+      if (Object.prototype.hasOwnProperty.call(val, k)) {
+        const transformed = transform((val as Record<string, unknown>)[k], k);
+        if (transformed !== undefined) {
+          out[k] = transformed;
+        }
+      }
+    }
+    return out;
+  };
+
+  return transform(schema) as SerializableFormSchema;
+}

--- a/packages/form-core/tests/field-meta.test.ts
+++ b/packages/form-core/tests/field-meta.test.ts
@@ -35,4 +35,25 @@ describe("field-meta", () => {
       expect(meta?.example).toEqual({ type: "tags", name: "skills", label: "Skills" });
     });
   });
+
+  describe("choice category", () => {
+    const choiceTypes: FieldType[] = ["select", "checkbox", "switch", "radio"];
+
+    it("has metadata for all choice types", () => {
+      choiceTypes.forEach((type) => {
+        const meta = getFieldMeta(type);
+        expect(meta).toBeDefined();
+        expect(meta?.type).toBe(type);
+        expect(meta?.category).toBe("choice");
+      });
+    });
+
+    it("getFieldsByCategory('choice') returns all choice fields", () => {
+      const choices = getFieldsByCategory("choice");
+      expect(choices.length).toBe(choiceTypes.length);
+      choices.forEach((meta) => {
+        expect(choiceTypes).toContain(meta.type);
+      });
+    });
+  });
 });

--- a/packages/form-core/tests/field-meta.test.ts
+++ b/packages/form-core/tests/field-meta.test.ts
@@ -56,4 +56,43 @@ describe("field-meta", () => {
       });
     });
   });
+
+  describe("container and layout categories", () => {
+    const containerTypes: FieldType[] = ["group", "array"];
+    const layoutTypes: FieldType[] = ["row", "tabs", "collapsible"];
+
+    it("has metadata for all container and layout types", () => {
+      [...containerTypes, ...layoutTypes].forEach((type) => {
+        const meta = getFieldMeta(type);
+        expect(meta).toBeDefined();
+        expect(meta?.hasChildren).toBe(true);
+      });
+    });
+
+    it("getFieldsByCategory works for container and layout", () => {
+      expect(getFieldsByCategory("container").length).toBe(containerTypes.length);
+      expect(getFieldsByCategory("layout").length).toBe(layoutTypes.length);
+    });
+    
+    it("layout fields do not have name or defaultValue in required/optional props", () => {
+      layoutTypes.forEach((type) => {
+        const meta = getFieldMeta(type);
+        expect(meta?.requiredProps).not.toContain("name");
+        expect(meta?.optionalProps).not.toContain("name");
+        expect(meta?.optionalProps).not.toContain("defaultValue");
+      });
+    });
+  });
+
+  describe("completeness", () => {
+    it("every FieldType has an entry", () => {
+      const allTypes: FieldType[] = [
+        "text", "email", "password", "textarea", "number", "select", "date", "tags",
+        "checkbox", "switch", "radio", "group", "array", "row", "tabs", "collapsible"
+      ];
+      allTypes.forEach((type) => {
+        expect(getFieldMeta(type)).toBeDefined();
+      });
+    });
+  });
 });

--- a/packages/form-core/tests/field-meta.test.ts
+++ b/packages/form-core/tests/field-meta.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { getFieldMeta, getFieldsByCategory } from "../src/field-meta";
+import type { FieldType } from "../src/types";
+
+describe("field-meta", () => {
+  describe("input category", () => {
+    const inputTypes: FieldType[] = ["text", "email", "password", "textarea", "number", "date", "tags"];
+
+    it("has metadata for all input types", () => {
+      inputTypes.forEach((type) => {
+        const meta = getFieldMeta(type);
+        expect(meta).toBeDefined();
+        expect(meta?.type).toBe(type);
+        expect(meta?.category).toBe("input");
+      });
+    });
+
+    it("getFieldsByCategory('input') returns all input fields", () => {
+      const inputs = getFieldsByCategory("input");
+      expect(inputs.length).toBe(inputTypes.length);
+      inputs.forEach((meta) => {
+        expect(inputTypes).toContain(meta.type);
+      });
+    });
+
+    it("has requiredProps and optionalProps for input fields", () => {
+      const meta = getFieldMeta("text");
+      expect(meta?.requiredProps).toContain("type");
+      expect(meta?.requiredProps).toContain("name");
+      expect(meta?.optionalProps).toContain("label");
+    });
+
+    it("example configs are structured correctly", () => {
+      const meta = getFieldMeta("tags");
+      expect(meta?.example).toEqual({ type: "tags", name: "skills", label: "Skills" });
+    });
+  });
+});

--- a/packages/form-core/tests/schema-fixer.test.ts
+++ b/packages/form-core/tests/schema-fixer.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { autoFixSchema } from "../src/schema-fixer";
+import { validateSchema } from "../src/schema-validator";
+import type { SerializableFormSchema, SerializableField } from "../src/serializable";
+
+type TestField = {
+  name?: string;
+  type?: string;
+  fields?: unknown[];
+  tabs?: { fields?: unknown[] }[];
+};
+
+describe("schema-fixer", () => {
+  it("normalizes known field type casing", () => {
+    const schema: SerializableFormSchema = {
+      fields: [
+        { type: "Text", name: "foo" } as unknown as SerializableField,
+        { type: "CHECKBOX", name: "bar", hasMany: true, options: [{ label: "1", value: "1" }] } as unknown as SerializableField,
+        { type: "UnknownType", name: "baz" } as unknown as SerializableField
+      ]
+    };
+    const fixed = autoFixSchema(schema);
+    expect(fixed.fields[0].type).toBe("text");
+    expect(fixed.fields[1].type).toBe("checkbox");
+    expect(fixed.fields[2].type).toBe("UnknownType");
+  });
+
+  it("generates name from label when missing", () => {
+    const schema: SerializableFormSchema = {
+      fields: [
+        { type: "text", label: "First Name*" } as unknown as SerializableField,
+        { type: "text", label: "Email Address" } as unknown as SerializableField,
+        { type: "text", name: "customName", label: "Custom" } as unknown as SerializableField
+      ]
+    };
+    const fixed = autoFixSchema(schema);
+    expect((fixed.fields[0] as TestField).name).toBe("firstName");
+    expect((fixed.fields[1] as TestField).name).toBe("emailAddress");
+    expect((fixed.fields[2] as TestField).name).toBe("customName");
+  });
+
+  it("removes name from layout fields", () => {
+    const schema: SerializableFormSchema = {
+      fields: [
+        { type: "row", name: "layoutRow", fields: [] } as unknown as SerializableField
+      ]
+    };
+    const fixed = autoFixSchema(schema);
+    expect((fixed.fields[0] as TestField).name).toBeUndefined();
+  });
+
+  it("adds missing fields arrays to containers", () => {
+    const schema: SerializableFormSchema = {
+      fields: [
+        { type: "group", name: "grp" } as unknown as SerializableField,
+        { type: "array", name: "arr" } as unknown as SerializableField
+      ]
+    };
+    const fixed = autoFixSchema(schema);
+    expect((fixed.fields[0] as TestField).fields).toEqual([]);
+    expect((fixed.fields[1] as TestField).fields).toEqual([]);
+  });
+
+  it("adds missing tabs arrays to tabs", () => {
+    const schema: SerializableFormSchema = {
+      fields: [
+        { type: "tabs" } as unknown as SerializableField,
+        { type: "tabs", tabs: [{ label: "A" }] } as unknown as SerializableField
+      ]
+    };
+    const fixed = autoFixSchema(schema);
+    expect((fixed.fields[0] as TestField).tabs).toEqual([]);
+    expect((fixed.fields[1] as TestField).tabs![0].fields).toEqual([]);
+  });
+
+  it("produces a schema that passes validation after fixing", () => {
+    const fixableSchema: SerializableFormSchema = {
+      fields: [
+        { 
+          type: "Group", 
+          label: "Personal Info"
+        } as unknown as SerializableField,
+        { 
+          type: "Tabs",
+          tabs: [
+            { label: "Settings" }
+          ]
+        } as unknown as SerializableField,
+        { 
+          type: "Row", 
+          name: "layout"
+        } as unknown as SerializableField
+      ]
+    };
+
+    const initialValidation = validateSchema(fixableSchema);
+    expect(initialValidation.valid).toBe(false);
+
+    const fixed = autoFixSchema(fixableSchema);
+    const fixedValidation = validateSchema(fixed);
+    expect(fixedValidation.valid).toBe(true);
+    expect(fixedValidation.issues).toHaveLength(0);
+  });
+
+  it("returns equivalent schema if already valid", () => {
+    const validSchema: SerializableFormSchema = {
+      fields: [
+        { type: "text", name: "firstName", label: "First Name" }
+      ]
+    };
+    const fixed = autoFixSchema(validSchema);
+    expect(fixed).toEqual(validSchema);
+  });
+});

--- a/packages/form-core/tests/schema-validator.test.ts
+++ b/packages/form-core/tests/schema-validator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { validateSchema } from "../src/schema-validator";
+import { validateSchema, formatSchemaIssues } from "../src/schema-validator";
 import type { SerializableFormSchema, SerializableField } from "../src/serializable";
 
 describe("schema-validator", () => {
@@ -236,6 +236,62 @@ describe("schema-validator", () => {
       const issues = result.issues.filter(i => i.code === "orphaned_resolver");
       expect(issues).toHaveLength(1);
       expect(issues[0].severity).toBe("warning");
+    });
+  });
+
+  describe("valid schema and deep nesting", () => {
+    it("validates a complex, deeply nested schema with zero issues", () => {
+      const schema: SerializableFormSchema = {
+        fields: [
+          {
+            type: "group",
+            name: "personal",
+            fields: [
+              { type: "text", name: "firstName", validations: [{ type: "required" }] } as unknown as SerializableField,
+              { type: "text", name: "lastName", condition: { $data: "firstName", "==": "John" } } as unknown as SerializableField
+            ]
+          },
+          {
+            type: "array",
+            name: "addresses",
+            primitive: false,
+            fields: [
+              {
+                type: "row",
+                fields: [
+                  { type: "text", name: "city" },
+                  { type: "text", name: "zip" }
+                ]
+              }
+            ]
+          },
+          {
+            type: "tabs",
+            tabs: [
+              {
+                label: "Settings",
+                fields: [
+                  { type: "checkbox", name: "notifications" }
+                ]
+              }
+            ]
+          }
+        ]
+      };
+      const result = validateSchema(schema);
+      expect(result.valid).toBe(true);
+      expect(result.issues).toHaveLength(0);
+    });
+
+    it("formats schema issues correctly", () => {
+      const issues = [
+        { code: "missing_name" as const, severity: "error" as const, path: "fields[0]", message: "msg 1" },
+        { code: "orphaned_resolver" as const, severity: "warning" as const, path: "fields[1]", message: "msg 2" }
+      ];
+      const formatted = formatSchemaIssues(issues);
+      expect(formatted).toHaveLength(2);
+      expect(formatted[0]).toBe("❌ Error [missing_name] at fields[0]: msg 1");
+      expect(formatted[1]).toBe("⚠️ Warning [orphaned_resolver] at fields[1]: msg 2");
     });
   });
 });

--- a/packages/form-core/tests/schema-validator.test.ts
+++ b/packages/form-core/tests/schema-validator.test.ts
@@ -188,4 +188,54 @@ describe("schema-validator", () => {
       expect(issues).toHaveLength(1);
     });
   });
+
+  describe("expression checks", () => {
+    it("flags invalid conditions", () => {
+      const schema: SerializableFormSchema = {
+        fields: [
+          { type: "text", name: "foo", condition: "bad" } as unknown as SerializableField,
+          { type: "text", name: "bar", condition: [] } as unknown as SerializableField
+        ]
+      };
+      const result = validateSchema(schema);
+      expect(result.valid).toBe(false);
+      const issues = result.issues.filter(i => i.code === "invalid_condition");
+      expect(issues).toHaveLength(2);
+    });
+
+    it("flags invalid validation types", () => {
+      const schema: SerializableFormSchema = {
+        fields: [
+          { 
+            type: "text", 
+            name: "foo", 
+            validations: [{ type: "minDate" }] // Not applicable to text
+          } as unknown as SerializableField,
+          { 
+            type: "number", 
+            name: "bar", 
+            validations: [{ type: "custom" }] // custom is always allowed
+          } as unknown as SerializableField
+        ]
+      };
+      const result = validateSchema(schema);
+      expect(result.valid).toBe(false);
+      const issues = result.issues.filter(i => i.code === "invalid_validation");
+      expect(issues).toHaveLength(1);
+      expect(issues[0].path).toBe("fields[0].validations[0]");
+    });
+
+    it("flags orphaned options resolver as warning", () => {
+      const schema: SerializableFormSchema = {
+        fields: [
+          { type: "select", name: "foo", options: [{ label: "1", value: "1" }], optionsResolver: "fetchOptions" } as unknown as SerializableField
+        ]
+      };
+      const result = validateSchema(schema);
+      expect(result.valid).toBe(true);
+      const issues = result.issues.filter(i => i.code === "orphaned_resolver");
+      expect(issues).toHaveLength(1);
+      expect(issues[0].severity).toBe("warning");
+    });
+  });
 });

--- a/packages/form-core/tests/schema-validator.test.ts
+++ b/packages/form-core/tests/schema-validator.test.ts
@@ -194,13 +194,29 @@ describe("schema-validator", () => {
       const schema: SerializableFormSchema = {
         fields: [
           { type: "text", name: "foo", condition: "bad" } as unknown as SerializableField,
-          { type: "text", name: "bar", condition: [] } as unknown as SerializableField
-        ]
+          { type: "text", name: "bar", condition: 123 } as unknown as SerializableField,
+        ],
       };
       const result = validateSchema(schema);
       expect(result.valid).toBe(false);
-      const issues = result.issues.filter(i => i.code === "invalid_condition");
+      const issues = result.issues.filter(
+        (i) => i.code === "invalid_condition",
+      );
       expect(issues).toHaveLength(2);
+    });
+
+    it("accepts boolean conditions", () => {
+      const schema: SerializableFormSchema = {
+        fields: [
+          { type: "text", name: "foo", condition: true },
+          { type: "text", name: "bar", condition: false },
+        ],
+      };
+      const result = validateSchema(schema);
+      expect(result.valid).toBe(true);
+      expect(
+        result.issues.filter((i) => i.code === "invalid_condition"),
+      ).toHaveLength(0);
     });
 
     it("flags invalid validation types", () => {

--- a/packages/form-core/tests/schema-validator.test.ts
+++ b/packages/form-core/tests/schema-validator.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { validateSchema } from "../src/schema-validator";
+import type { SerializableFormSchema } from "../src/serializable";
+
+describe("schema-validator", () => {
+  describe("field identity checks", () => {
+    it("flags missing names on data fields", () => {
+      const schema: SerializableFormSchema = {
+        fields: [
+          { type: "text", name: "" }, // missing
+          { type: "number", name: "  " }, // blank
+          { type: "email", name: "email" } // valid
+        ]
+      };
+      const result = validateSchema(schema);
+      expect(result.valid).toBe(false);
+      const missingNameIssues = result.issues.filter(i => i.code === "missing_name");
+      expect(missingNameIssues).toHaveLength(2);
+      expect(missingNameIssues[0].path).toBe("fields[0]");
+      expect(missingNameIssues[1].path).toBe("fields[1]");
+    });
+
+    it("flags duplicate names among siblings", () => {
+      const schema: SerializableFormSchema = {
+        fields: [
+          { type: "text", name: "foo" },
+          { type: "number", name: "foo" }, // duplicate
+          { type: "email", name: "bar" }
+        ]
+      };
+      const result = validateSchema(schema);
+      expect(result.valid).toBe(false);
+      const duplicates = result.issues.filter(i => i.code === "duplicate_name");
+      expect(duplicates).toHaveLength(1);
+      expect(duplicates[0].path).toBe("fields[1]");
+      expect(duplicates[0].message).toContain("'foo'");
+    });
+
+    it("allows same name at different nesting levels", () => {
+      const schema: SerializableFormSchema = {
+        fields: [
+          { type: "text", name: "foo" },
+          { 
+            type: "group", 
+            name: "nested",
+            fields: [{ type: "text", name: "foo" }] // valid, different level
+          }
+        ]
+      };
+      const result = validateSchema(schema);
+      expect(result.issues.filter(i => i.code === "duplicate_name")).toHaveLength(0);
+    });
+
+    it("allows missing name on layout fields", () => {
+      const schema: SerializableFormSchema = {
+        fields: [
+          { type: "row", fields: [] }
+        ]
+      };
+      const result = validateSchema(schema);
+      expect(result.issues).toHaveLength(0);
+      expect(result.valid).toBe(true);
+    });
+
+    it("allows missing name on primitive array items", () => {
+      const schema: SerializableFormSchema = {
+        fields: [
+          { 
+            type: "array", 
+            name: "tags", 
+            primitive: true,
+            fields: [{ type: "text", name: "" }] // allowed for primitive array item
+          }
+        ]
+      };
+      const result = validateSchema(schema);
+      expect(result.issues).toHaveLength(0);
+      expect(result.valid).toBe(true);
+    });
+  });
+});

--- a/packages/form-core/tests/schema-validator.test.ts
+++ b/packages/form-core/tests/schema-validator.test.ts
@@ -146,4 +146,46 @@ describe("schema-validator", () => {
       expect(result.issues.filter(i => i.code === "missing_fields")).toHaveLength(1);
     });
   });
+
+  describe("type checks", () => {
+    it("flags invalid field types", () => {
+      const schema: SerializableFormSchema = {
+        fields: [
+          { type: "magic", name: "foo" } as unknown as SerializableField
+        ]
+      };
+      const result = validateSchema(schema);
+      expect(result.valid).toBe(false);
+      const issues = result.issues.filter(i => i.code === "invalid_field_type");
+      expect(issues).toHaveLength(1);
+    });
+
+    it("still traverses invalid fields if they have a fields array", () => {
+      const schema: SerializableFormSchema = {
+        fields: [
+          { 
+            type: "custom-container", 
+            name: "foo", 
+            fields: [{ type: "text", name: "" }] 
+          } as unknown as SerializableField
+        ]
+      };
+      const result = validateSchema(schema);
+      expect(result.valid).toBe(false);
+      expect(result.issues.filter(i => i.code === "invalid_field_type")).toHaveLength(1);
+      expect(result.issues.filter(i => i.code === "missing_name")).toHaveLength(1);
+    });
+
+    it("flags name on layout fields", () => {
+      const schema: SerializableFormSchema = {
+        fields: [
+          { type: "row", name: "bad_name", fields: [] } as unknown as SerializableField
+        ]
+      };
+      const result = validateSchema(schema);
+      expect(result.valid).toBe(false);
+      const issues = result.issues.filter(i => i.code === "name_in_layout");
+      expect(issues).toHaveLength(1);
+    });
+  });
 });

--- a/packages/form-core/tests/schema-validator.test.ts
+++ b/packages/form-core/tests/schema-validator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { validateSchema } from "../src/schema-validator";
-import type { SerializableFormSchema } from "../src/serializable";
+import type { SerializableFormSchema, SerializableField } from "../src/serializable";
 
 describe("schema-validator", () => {
   describe("field identity checks", () => {
@@ -76,6 +76,74 @@ describe("schema-validator", () => {
       const result = validateSchema(schema);
       expect(result.issues).toHaveLength(0);
       expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("structure checks", () => {
+    it("flags missing options for choice fields", () => {
+      const schema: SerializableFormSchema = {
+        fields: [
+          { type: "select", name: "foo" } as unknown as SerializableField, // missing
+          { type: "radio", name: "bar", options: [] }, // empty
+          { type: "checkbox", name: "baz", hasMany: true } as unknown as SerializableField // missing (group)
+        ]
+      };
+      const result = validateSchema(schema);
+      expect(result.valid).toBe(false);
+      const issues = result.issues.filter(i => i.code === "missing_options");
+      expect(issues).toHaveLength(3);
+    });
+
+    it("allows checkbox without hasMany to not have options", () => {
+      const schema: SerializableFormSchema = {
+        fields: [{ type: "checkbox", name: "foo" }]
+      };
+      const result = validateSchema(schema);
+      expect(result.valid).toBe(true);
+    });
+
+    it("flags missing fields array in containers", () => {
+      const schema: SerializableFormSchema = {
+        fields: [
+          { type: "group", name: "foo" } as unknown as SerializableField,
+          { type: "row" } as unknown as SerializableField
+        ]
+      };
+      const result = validateSchema(schema);
+      expect(result.valid).toBe(false);
+      const issues = result.issues.filter(i => i.code === "missing_fields");
+      expect(issues).toHaveLength(2);
+    });
+
+    it("flags primitive array with multiple child fields", () => {
+      const schema: SerializableFormSchema = {
+        fields: [
+          { 
+            type: "array", 
+            name: "foo", 
+            primitive: true, 
+            // @ts-expect-error - testing invalid state with multiple children
+            fields: [{ type: "text", name: "a" }, { type: "text", name: "b" }]
+          }
+        ]
+      };
+      const result = validateSchema(schema);
+      expect(result.valid).toBe(false);
+      const issues = result.issues.filter(i => i.code === "primitive_array_multi");
+      expect(issues).toHaveLength(1);
+    });
+
+    it("flags empty tabs and missing tab fields", () => {
+      const schema: SerializableFormSchema = {
+        fields: [
+          { type: "tabs", tabs: [] },
+          { type: "tabs", tabs: [{ label: "A" }] as unknown as { label: string; fields: SerializableField[] }[] } // missing fields
+        ]
+      };
+      const result = validateSchema(schema);
+      expect(result.valid).toBe(false);
+      expect(result.issues.filter(i => i.code === "empty_tabs")).toHaveLength(1);
+      expect(result.issues.filter(i => i.code === "missing_fields")).toHaveLength(1);
     });
   });
 });

--- a/packages/form-core/tests/serializable.test.ts
+++ b/packages/form-core/tests/serializable.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { isSerializable, toSerializable } from "../src/serializable";
+import { isSerializable, toSerializable, serializeSchema, deserializeSchema } from "../src/serializable";
+import type { SerializableFormSchema, SerializableTextField } from "../src/serializable";
 import type { FormSchema } from "../src/types";
-import type { SerializableTextField } from "../src/serializable";
+
 
 describe("serializable", () => {
   describe("isSerializable", () => {
@@ -91,6 +92,47 @@ describe("serializable", () => {
       };
       const serializable = toSerializable(schema);
       expect((serializable.fields[0] as { condition?: unknown }).condition).toEqual({ $data: "bar", eq: "baz" });
+    });
+  });
+
+  describe("serializeSchema", () => {
+    it("returns deterministic JSON", () => {
+      const s1: SerializableFormSchema = {
+        fields: [
+          { type: "text", name: "foo", label: "Foo", required: true }
+        ]
+      };
+      const s2: SerializableFormSchema = {
+        fields: [
+          { required: true, name: "foo", label: "Foo", type: "text" }
+        ]
+      };
+      expect(serializeSchema(s1)).toBe(serializeSchema(s2));
+      expect(serializeSchema(s1)).toBe(`{"fields":[{"label":"Foo","name":"foo","required":true,"type":"text"}]}`);
+    });
+  });
+
+  describe("deserializeSchema", () => {
+    it("parses valid schema", () => {
+      const json = `{"fields":[{"type":"text","name":"foo"}]}`;
+      const schema = deserializeSchema(json);
+      expect(schema.fields).toHaveLength(1);
+    });
+
+    it("throws on invalid JSON", () => {
+      expect(() => deserializeSchema(`{ broken`)).toThrow("Failed to parse schema");
+    });
+
+    it("throws on missing fields array", () => {
+      expect(() => deserializeSchema(`{"title":"foo"}`)).toThrow("Invalid schema structure");
+    });
+
+    it("round-trips correctly", () => {
+      const s: SerializableFormSchema = {
+        fields: [{ type: "text", name: "foo", label: "Foo" }]
+      };
+      const parsed = deserializeSchema(serializeSchema(s));
+      expect(parsed).toEqual(s);
     });
   });
 });

--- a/packages/form-core/tests/serializable.test.ts
+++ b/packages/form-core/tests/serializable.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { isSerializable, toSerializable } from "../src/serializable";
+import type { FormSchema } from "../src/types";
+import type { SerializableTextField } from "../src/serializable";
+
+describe("serializable", () => {
+  describe("isSerializable", () => {
+    it("returns true for pure JSON schemas", () => {
+      const schema: FormSchema = {
+        fields: [
+          { type: "text", name: "foo", label: "Foo" }
+        ]
+      };
+      expect(isSerializable(schema)).toBe(true);
+    });
+
+    it("returns false if schema contains functions", () => {
+      const schema: FormSchema = {
+        fields: [
+          { type: "text", name: "foo", label: (() => "Foo") as unknown as string }
+        ]
+      };
+      expect(isSerializable(schema)).toBe(false);
+    });
+
+    it("returns false if schema contains FrameworkText (React nodes)", () => {
+      const schema: FormSchema = {
+        fields: [
+          { type: "text", name: "foo", label: { $$typeof: Symbol.for("react.element") } as unknown as string }
+        ]
+      };
+      expect(isSerializable(schema)).toBe(false);
+    });
+  });
+
+  describe("toSerializable", () => {
+    it("strips functions and replaces them with undefined", () => {
+      const schema: FormSchema = {
+        fields: [
+          {
+            type: "text",
+            name: "foo",
+            condition: (() => true) as unknown as boolean,
+            label: "Foo"
+          }
+        ]
+      };
+      const serializable = toSerializable(schema);
+      expect((serializable.fields[0] as { condition?: unknown }).condition).toBeUndefined();
+      expect((serializable.fields[0] as SerializableTextField).label).toBe("Foo");
+    });
+
+    it("replaces OptionResolverFn with an empty array", () => {
+      const schema: FormSchema = {
+        fields: [
+          {
+            type: "select",
+            name: "foo",
+            options: (() => []) as unknown as string[]
+          }
+        ]
+      };
+      const serializable = toSerializable(schema);
+      expect((serializable.fields[0] as { options?: unknown }).options).toEqual([]);
+    });
+
+    it("converts FrameworkText to string", () => {
+      const reactNode = { $$typeof: Symbol.for("react.element"), toString: () => "MyNode" };
+      const schema: FormSchema = {
+        fields: [
+          {
+            type: "text",
+            name: "foo",
+            label: reactNode as unknown as string
+          }
+        ]
+      };
+      const serializable = toSerializable(schema);
+      expect((serializable.fields[0] as SerializableTextField).label).toBe(String(reactNode));
+    });
+
+    it("preserves valid serializable nodes", () => {
+      const schema: FormSchema = {
+        fields: [
+          {
+            type: "text",
+            name: "foo",
+            condition: { $data: "bar", eq: "baz" }
+          }
+        ]
+      };
+      const serializable = toSerializable(schema);
+      expect((serializable.fields[0] as { condition?: unknown }).condition).toEqual({ $data: "bar", eq: "baz" });
+    });
+  });
+});


### PR DESCRIPTION
## Description

Add serializable schema types, validator, and metadata to `form-core` to support headless form builder operations and AI-assisted schema generation.

## Key Changes

### Core (`form-core`)

- Add `SerializableFormSchema` and related types for JSON-safe schema representations.
- Implement `validateSchema` to ensure structural integrity and field identity uniqueness.
- Implement `autoFixSchema` to automatically correct common schema issues (casing, missing names, etc.).
- Add `FIELD_TYPE_META` registry for discovering field capabilities and properties.
- Export serialization utilities: `isSerializable`, `toSerializable`, `serializeSchema`, and `deserializeSchema`.

### Other

- Add comprehensive unit tests for all new core primitives and utilities.

## Type of change

- [x] `feat` (New feature)
- [ ] `fix` (Bug fix)
- [ ] `docs` (Documentation changes)
- [ ] `refactor` (Refactoring code without changing behavior)
- [x] `test` (Adding or updating tests)
- [ ] `chore` (Maintenance, CI/CD, or Ops-related changes)

## Related Issues

- Closes #