### PR TITLE
chore: upgrade TanStack Form to 1.32.0

### DIFF
--- a/.changeset/upgrade-tanstack.md
+++ b/.changeset/upgrade-tanstack.md
@@ -1,0 +1,8 @@
+---
+"@buildnbuzz/form-react": patch
+---
+
+Upgrade TanStack Form dependencies to the latest version.
+
+- Update `@tanstack/form-core` to `^1.32.0`.
+- Update `@tanstack/react-form` to `^1.32.0`.

--- a/packages/form-react/package.json
+++ b/packages/form-react/package.json
@@ -48,8 +48,8 @@
   },
   "dependencies": {
     "@buildnbuzz/form-core": "workspace:^",
-    "@tanstack/form-core": "^1.28.5",
-    "@tanstack/react-form": "^1.28.5"
+    "@tanstack/form-core": "^1.32.0",
+    "@tanstack/react-form": "^1.32.0"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,11 +422,11 @@ importers:
         specifier: workspace:^
         version: link:../form-core
       '@tanstack/form-core':
-        specifier: ^1.28.5
-        version: 1.28.6
+        specifier: ^1.32.0
+        version: 1.32.0
       '@tanstack/react-form':
-        specifier: ^1.28.5
-        version: 1.28.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^1.32.0
+        version: 1.32.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:^
@@ -2223,15 +2223,15 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@tanstack/form-core@1.28.6':
-    resolution: {integrity: sha512-4zroxL6VDj5O+w7l3dYZnUeL/h30KtNSV7UWzKAL7cl+8clMFdISPDlDlluS37As7oqvPVKo8B83VlIBvgmRog==}
+  '@tanstack/form-core@1.32.0':
+    resolution: {integrity: sha512-Tn5VRDSjyqjmaet2tJMuEWDRFyrCaon03vxXPlSSaiSs6C/N7lCIwGCXJbZXEUq1kTj8jYN9qyXHbsz4LQHcow==}
 
   '@tanstack/pacer-lite@0.1.1':
     resolution: {integrity: sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w==}
     engines: {node: '>=18'}
 
-  '@tanstack/react-form@1.28.6':
-    resolution: {integrity: sha512-dRxwKeNW3uuJvf0sXsIQ2compFMnIJNk9B436Lx0fqkqK+CBvA1tNmEdX+faoCpuQ5Wua3c8ahVibJ65cpkijA==}
+  '@tanstack/react-form@1.32.0':
+    resolution: {integrity: sha512-6WP5SQTA6/H9crCpvpq3ZppYWqtrdE5NjOy6ebABi6uAQPqhfTzrdjS9t40mCZCFtGI5585OhJV6zBP/KN2zcw==}
     peerDependencies:
       '@tanstack/react-start': '*'
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -8143,7 +8143,7 @@ snapshots:
 
   '@tanstack/devtools-event-client@0.4.3': {}
 
-  '@tanstack/form-core@1.28.6':
+  '@tanstack/form-core@1.32.0':
     dependencies:
       '@tanstack/devtools-event-client': 0.4.3
       '@tanstack/pacer-lite': 0.1.1
@@ -8151,9 +8151,9 @@ snapshots:
 
   '@tanstack/pacer-lite@0.1.1': {}
 
-  '@tanstack/react-form@1.28.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@tanstack/react-form@1.32.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@tanstack/form-core': 1.28.6
+      '@tanstack/form-core': 1.32.0
       '@tanstack/react-store': 0.9.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Description
Upgrade TanStack Form dependencies to the latest version across the monorepo.

## Key Changes
### @buildnbuzz/form-react
- Upgraded `@tanstack/form-core` to `^1.32.0`
- Upgraded `@tanstack/react-form` to `^1.32.0`

## Type of Change
- [x] Internal/Dependency Upgrade