### PR TITLE
fix(form-react): set combobox id for select field having hasMany

### DIFF
--- a/apps/web/registry/shadcn/fields/select.tsx
+++ b/apps/web/registry/shadcn/fields/select.tsx
@@ -160,6 +160,7 @@ export function SelectField() {
 
         <FieldContent>
           <Combobox
+            id={hasMany ? fieldApi.name : undefined}
             items={options}
             multiple={hasMany}
             value={selectedValues}
@@ -182,9 +183,7 @@ export function SelectField() {
                   {(values: NormalizedOption[]) => (
                     <React.Fragment>
                       {values.map((opt) => (
-                        <ComboboxChip key={opt.value}>
-                          {opt.label}
-                        </ComboboxChip>
+                        <ComboboxChip key={opt.value}>{opt.label}</ComboboxChip>
                       ))}
                       <ComboboxChipsInput
                         disabled={isDisabled || isReadOnly || isLoading}


### PR DESCRIPTION
## Description

Fixes [#170](https://github.com/buildnbuzz/buzzform/issues/170) — clicking the label for a multi-select (`hasMany: true`) field did not focus the control, while single-select worked as expected.

For single select, `FieldLabel` uses `htmlFor={fieldApi.name}` and that id is set on `ComboboxInput`. For multi select, the UI uses `ComboboxChips` / `ComboboxChipsInput` instead, so no element had the matching id and label clicks had no effect.

This change passes `id={fieldApi.name}` to `Combobox` when `hasMany` is true so the label’s `htmlFor` associates with the multi-select input.

## Changes

### React Adapter (`form-react`)

- `apps/web/registry/shadcn/fields/select.tsx`: set `id={hasMany ? fieldApi.name : undefined}` on `Combobox` for multi-select fields

## Type of change

- [ ] `feat` (New feature)
- [x] `fix` (Bug fix)
- [ ] `docs` (Documentation changes)
- [ ] `refactor` (Refactoring code without changing behavior)
- [ ] `test` (Adding or updating tests)
- [ ] `chore` (Maintenance, CI/CD, or Ops-related changes)

## Related Issues

- Closes #170
