### PR TITLE
chore: fix support Node.js 25+ in tests

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+
+const nodeMajor = Number(process.versions.node.split(".")[0]);
+
+// Node 25+ ships Web Storage on globalThis by default. The built-in localStorage
+// is incomplete without --localstorage-file, so jsdom skips its polyfill and tests
+// that call localStorage.clear() fail. --no-webstorage disables Node's API so jsdom
+// can provide a full Storage implementation.
+// On Node < 25 the flag does not exist (CI uses Node 20), so we must omit it there.
+const modernNodeExecArgv = nodeMajor >= 25 ? ["--no-webstorage"] : [];
+
+export default defineConfig({
+  test: {
+    execArgv: modernNodeExecArgv,
+  },
+});


### PR DESCRIPTION
## Description

Fixes support for Node 25+ in tests.

## Key Changes

### Other

- Adds `--no-webstorage` argument for Node 25+ in the tests runner

## Type of change

- [ ] `feat` (New feature)
- [ ] `fix` (Bug fix)
- [ ] `docs` (Documentation changes)
- [ ] `refactor` (Refactoring code without changing behavior)
- [ ] `test` (Adding or updating tests)
- [X] `chore` (Maintenance, CI/CD, or Ops-related changes)

## Related Issues

- Closes #173
