### PR TITLE
chore: add root ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,25 @@
+import { defineConfig } from "eslint/config";
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default defineConfig([
+	{
+		files: ["**/*.js"],
+		plugins: { js },
+		extends: ["js/recommended"],
+		rules: {
+			"no-unused-vars": "warn",
+			"no-undef": "warn",
+		},
+	},
+	...tseslint.configs.recommended.map((config) => ({
+		...config,
+		files: ["**/*.{ts,tsx}"],
+	})),
+	{
+		files: ["**/*.{ts,tsx}"],
+		rules: {
+			"@typescript-eslint/no-unused-vars": "warn",
+		},
+	},
+]);

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.29.8",
+    "@eslint/js": "^9.39.1",
     "@types/node": "^22.15.3",
     "eslint": "^9.39.1",
+    "typescript-eslint": "^8.50.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "prettier": "^3.7.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.29.8(@types/node@22.15.3)
+      '@eslint/js':
+        specifier: ^9.39.1
+        version: 9.39.2
       '@types/node':
         specifier: ^22.15.3
         version: 22.15.3
@@ -45,6 +48,9 @@ importers:
       typescript:
         specifier: 5.9.2
         version: 5.9.2
+      typescript-eslint:
+        specifier: ^8.50.0
+        version: 8.51.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2)
       vitest:
         specifier: ^4.0.18
         version: 4.1.0(@types/node@22.15.3)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.7(@types/node@22.15.3)(typescript@5.9.2))(vite@8.0.1(@types/node@22.15.3)(esbuild@0.27.2)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))


### PR DESCRIPTION
## Description

Adds a root-level ESLint flat config so lint checks run without manual setup. This unblocks CI and local workflows that expect ESLint to be configured out of the box.

## Key Changes

### Core (`form-core`)

- N/A

### React Adapter (`form-react`)

- N/A

### Docs / Web (`apps/web`)

- N/A

### Other

- Add `eslint.config.js` with flat config for `**/*.js` and `**/*.{ts,tsx}` using `@eslint/js` and `typescript-eslint` recommended presets
- Set unused-variable rules to `warn` for both JS and TypeScript
- Add `@eslint/js` and `typescript-eslint` as root dev dependencies

## Type of change

- [ ] `feat` (New feature)
- [ ] `fix` (Bug fix)
- [ ] `docs` (Documentation changes)
- [ ] `refactor` (Refactoring code without changing behavior)
- [ ] `test` (Adding or updating tests)
- [x] `chore` (Maintenance, CI/CD, or Ops-related changes)

## Related Issues

- Closes #173

## Test plan

- [ ] Run `pnpm lint` from the repo root and confirm ESLint runs without extra config
- [ ] Verify CI lint step passes with the new config

Made with [Cursor](https://cursor.com)